### PR TITLE
Support JSX tag auto close

### DIFF
--- a/languages/astro/config.toml
+++ b/languages/astro/config.toml
@@ -18,6 +18,14 @@ scope_opt_in_language_servers = ["tailwindcss-language-server"]
 prettier_parser_name = "astro"
 prettier_plugins = ["prettier-plugin-astro"]
 
+[jsx_tag_auto_close]
+open_tag_node_name = "start_tag"
+close_tag_node_name = "end_tag"
+jsx_element_node_name = "element"
+tag_name_node_name = "tag_name"
+erroneous_close_tag_node_name = "erroneous_end_tag"
+erroneous_close_tag_name_node_name = "erroneous_end_tag_name"
+
 [overrides.string]
 word_characters = ["-"]
 opt_into_language_servers = ["tailwindcss-language-server"]


### PR DESCRIPTION
Support for JSX tag auto-closing will be [landing soon in Zed](https://github.com/zed-industries/zed/pull/25681)

This PR adds the necessary configuration to this plugin in order to allow users to enable tag auto closing
