### PR TITLE
Add workaround for leading `/` on Windows paths

### DIFF
--- a/src/astro.rs
+++ b/src/astro.rs
@@ -113,8 +113,7 @@ impl AstroExtension {
             println!("typescript already installed");
         }
 
-        self.typescript_tsdk_path = env::current_dir()
-            .unwrap()
+        self.typescript_tsdk_path = zed_ext::sanitize_windows_path(env::current_dir().unwrap())
             .join(TYPESCRIPT_TSDK_PATH)
             .to_string_lossy()
             .to_string();
@@ -140,8 +139,7 @@ impl zed::Extension for AstroExtension {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                env::current_dir()
-                    .unwrap()
+                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
                     .join(&server_path)
                     .to_string_lossy()
                     .to_string(),
@@ -166,3 +164,25 @@ impl zed::Extension for AstroExtension {
 }
 
 zed::register_extension!(AstroExtension);
+
+/// Extensions to the Zed extension API that have not yet stabilized.
+mod zed_ext {
+    /// Sanitizes the given path to remove the leading `/` on Windows.
+    ///
+    /// On macOS and Linux this is a no-op.
+    ///
+    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
+    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        use zed_extension_api::{current_platform, Os};
+
+        let (os, _arch) = current_platform();
+        match os {
+            Os::Mac | Os::Linux => path,
+            Os::Windows => path
+                .to_string_lossy()
+                .to_string()
+                .trim_start_matches('/')
+                .into(),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a workaround for the leading `/` on Windows paths (https://github.com/zed-industries/zed/issues/20559).