### PR TITLE
Improve tag auto-indent

### DIFF
--- a/languages/astro/brackets.scm
+++ b/languages/astro/brackets.scm
@@ -1,3 +1,5 @@
 ("{" @open "}" @close)
 ("<" @open ">" @close)
 ("\"" @open "\"" @close)
+
+((element (start_tag) @open [(end_tag) (erroneous_end_tag)] @close) (#set! newline.only))

--- a/languages/astro/indents.scm
+++ b/languages/astro/indents.scm
@@ -1,0 +1,3 @@
+(element
+  (start_tag) @start
+  [(end_tag) (erroneous_end_tag)]? @end) @indent


### PR DESCRIPTION
Adds auto-indent and newline.only queries. This makes it so when hitting enter between an open and closing tag like so
```html
<div>|</div>
```
The result is:
```html
<div>
    |
</div>
```
Instead of:
```html
<div>
|</div>
```
