### PR TITLE
Bump version to v0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "zed_astro"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "serde",
  "zed_extension_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_astro"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "astro"
 name = "Astro"
 description = "Astro support."
-version = "0.1.7"
+version = "0.1.8"
 schema_version = 1
 authors = ["Alvaro Gaona <alvgaona@gmail.com>", "0xk1f0 <dev@k1f0.dev>"]
 repository = "https://github.com/zed-extensions/astro"


### PR DESCRIPTION
This PR bumps the version of the extension to 0.1.8.

Includes: 
- https://github.com/zed-extensions/astro/pull/13
- https://github.com/zed-extensions/astro/pull/15
