### PR TITLE
Add comment injection for TODO/FIXME highlighting

### DIFF
--- a/languages/astro/injections.scm
+++ b/languages/astro/injections.scm
@@ -19,3 +19,8 @@
 (style_element
   (raw_text) @content
   (#set! "language" "css"))
+
+; Inject comment language for TODO, FIXME, etc. highlighting
+  ((comment) @content
+    (#set! injection.language "comment"))
+  


### PR DESCRIPTION
 ## Description

  This PR adds support for highlighting special comments (TODO, FIXME, ERROR, WARN, etc.) in Astro files when used with
   the [zed-comment](https://github.com/thedadams/zed-comment) extension.

  ## Changes

  - Added comment language injection to `languages/astro/injections.scm`

  ## Benefits

  - Users will be able to see TODO, FIXME, and other special comments highlighted with theme-appropriate colors
  - Improves code readability and developer experience when working with Astro files in Zed

  ## Testing

  Tested locally by adding the injection to the extension's `injections.scm` file and verifying that comments like

  `<!-- TODO: example -->` are properly highlighted in Astro files.
  `<!-- WIP: example -->` are properly highlighted in Astro files.
  `<!-- INFO: example -->` are properly highlighted in Astro files.
  `<!-- XXX: example -->` are properly highlighted in Astro files.
  `<!-- DOCS: example -->` are properly highlighted in Astro files.
  `<!-- PERF: example -->` are properly highlighted in Astro files.
  `<!-- TEST: example -->` are properly highlighted in Astro files.
  `<!-- ERROR: example -->` are properly highlighted in Astro files.
  `<!-- FIXME: example -->` are properly highlighted in Astro files.
  `<!-- BUG: example -->` are properly highlighted in Astro files.
  `<!-- WARN: example -->` are properly highlighted in Astro files.
  `<!-- HACK: example -->` are properly highlighted in Astro files.
  `<!-- WARNING: example -->` are properly highlighted in Astro files.
  `<!-- FIX: example -->` are properly highlighted in Astro files.

  ## Related

  - zed-comment extension: https://github.com/thedadams/zed-comment