### PR TITLE
Add SCSS and Less highlighting for style elements

### DIFF
--- a/languages/astro/injections.scm
+++ b/languages/astro/injections.scm
@@ -1,21 +1,54 @@
 (frontmatter
-  (frontmatter_js_block) @content
-  (#set! "language" "typescript"))
+  (frontmatter_js_block) @injection.content
+  (#set! injection.language "typescript"))
 
 (attribute_interpolation
-  (attribute_js_expr) @content
-  (#set! "language" "typescript"))
+  (attribute_js_expr) @injection.content
+  (#set! injection.language "typescript"))
 
 (html_interpolation
-  (permissible_text) @content
-  (#set! "language" "typescript"))
+  (permissible_text) @injection.content
+  (#set! injection.language "typescript"))
 
 (script_element
-  (raw_text) @content
-  (#set! "language" "typescript"))
+  (raw_text) @injection.content
+  (#set! injection.language "typescript"))
 
-; TODO: add scss/less or more injections
-; https://github.com/virchau13/tree-sitter-astro/blob/4be180759ec13651f72bacee65fa477c64222a1a/queries/injections.scm#L18-L27
 (style_element
-  (raw_text) @content
-  (#set! "language" "css"))
+  (start_tag
+    (attribute
+      (attribute_name) @_scss_attr
+      (quoted_attribute_value
+        (attribute_value) @_scss_value)))
+  (raw_text) @injection.content
+  (#eq? @_scss_attr "lang")
+  (#eq? @_scss_value "scss")
+  (#set! injection.language "scss"))
+
+(style_element
+  (start_tag
+    (attribute
+      (attribute_name) @_less_attr
+      (quoted_attribute_value
+        (attribute_value) @_less_value)))
+  (raw_text) @injection.content
+  (#eq? @_less_attr "lang")
+  (#eq? @_less_value "less")
+  (#set! injection.language "less"))
+
+(style_element
+  (start_tag
+    (attribute
+      (attribute_name) @_css_attr
+      (quoted_attribute_value
+        (attribute_value) @_css_value)))
+  (raw_text) @injection.content
+  (#eq? @_css_attr "lang")
+  (#eq? @_css_value "css")
+  (#set! injection.language "css"))
+
+(style_element
+  (start_tag) @_start_tag
+  (raw_text) @injection.content
+  (#not-match? @_start_tag "lang=")
+  (#set! injection.language "css"))


### PR DESCRIPTION
Add SCSS and Less syntax highlighting support for `<style>` elements with `lang="scss"` and `lang="less"` attributes.

**Note:** Required switching to the modern tree-sitter injection syntax (`@injection.content` and `#set! injection.language`) to make it work.